### PR TITLE
Fix crashes on add picture camera

### DIFF
--- a/app/src/main/java/com/example/csce546_project/CameraPreview.kt
+++ b/app/src/main/java/com/example/csce546_project/CameraPreview.kt
@@ -30,7 +30,7 @@ private fun bindPreview(
 	}
 
 	val cameraSelector = CameraSelector.Builder()
-		.requireLensFacing(CameraSelector.LENS_FACING_FRONT) //SWITCHED TO SELFIE
+		.requireLensFacing(CameraSelector.LENS_FACING_FRONT)
 		.build()
 
 	cameraProvider.unbindAll()

--- a/app/src/main/java/com/example/csce546_project/MainScreen.kt
+++ b/app/src/main/java/com/example/csce546_project/MainScreen.kt
@@ -83,6 +83,8 @@ fun MainScreen() {
 	val faceNetModel = FaceNetModel(context, modelInfo , useGpu )
 
 
+	val cameraProvider = ProcessCameraProvider.getInstance(context).get()
+
 	// START MAIN SCREEN
 	Box (
 		modifier = Modifier.fillMaxHeight()

--- a/app/src/main/java/com/example/csce546_project/MainScreen.kt
+++ b/app/src/main/java/com/example/csce546_project/MainScreen.kt
@@ -3,7 +3,10 @@ package com.example.csce546_project
 import android.Manifest
 import android.graphics.Bitmap
 import android.graphics.Matrix
+import androidx.camera.core.CameraSelector
 import androidx.camera.core.ImageCapture
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.view.LifecycleCameraController
 import androidx.camera.view.PreviewView
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -56,6 +59,11 @@ fun MainScreen() {
 	val cameraPermissionState = rememberPermissionState(
 		Manifest.permission.CAMERA
 	)
+	val cameraController = remember {
+		LifecycleCameraController(context).apply {
+			setCameraSelector(CameraSelector.DEFAULT_FRONT_CAMERA)
+		}
+	}
 
 	// PictureViewModel info -- keeps track of pictures and popup state
 	val viewModel: PictureViewModel = viewModel() // View model is singleton
@@ -63,6 +71,7 @@ fun MainScreen() {
 	val currentPicture by viewModel.currentPicture.collectAsState()  // TODO re-implement
 	val showAdd by viewModel.showAddPopup.collectAsState()
 	val showEdit by viewModel.showEditPopup.collectAsState()
+	val enableCamera by viewModel.enableBackgroundCamera.collectAsState()
 
 	// Cam's AI Boxes
 	var faces by remember { mutableStateOf(emptyList<Face>()) }
@@ -73,8 +82,6 @@ fun MainScreen() {
 	val useGpu = true
 	val faceNetModel = FaceNetModel(context, modelInfo , useGpu )
 
-
-	val TEST_PICTURE = PictureEntry(0, "Example", "exampleFilePath")  // TODO
 
 	// START MAIN SCREEN
 	Box (
@@ -90,7 +97,7 @@ fun MainScreen() {
 				),
 				alignment = Alignment.Center
 			) {
-				AddPopup(viewModel, { viewModel.closePopup() })
+				AddPopup(viewModel, cameraController, lifecycleOwner) { viewModel.closePopup() }
 			}
 		}
 		else if (showEdit) {
@@ -102,7 +109,7 @@ fun MainScreen() {
 				),
 				alignment = Alignment.Center
 			) {
-				EditPopup(viewModel, { viewModel.closePopup() })
+				EditPopup(viewModel) { viewModel.closePopup() }
 			}
 		}
 
@@ -116,10 +123,9 @@ fun MainScreen() {
 					.fillMaxWidth()
 					.fillMaxHeight(0.5f)  // TODO figure out how to clip camera preview
 			) {
-				if (cameraPermissionState.status.isGranted) {
+				if (cameraPermissionState.status.isGranted && enableCamera) {
 					// Box Representing Image Preview
 					Box(modifier = Modifier) {
-						// TODO: Switch to selfie camera or have toggle.
 						CameraPreview(
 							previewView = previewView,
 							imageCapture = imageCapture,
@@ -175,14 +181,18 @@ fun MainScreen() {
 				modifier = Modifier.fillMaxWidth().fillMaxHeight().background(color = Color.Red)
 			) {
 				Button(
-					onClick = { viewModel.openAddPopup() },
+					onClick = {
+						viewModel.openAddPopup()
+					}
 				) {
 					Text("Test add popup")
 				}
 
 				pictures.forEach { picture ->
 					Button(
-						onClick = { viewModel.openEditPopup(picture) }
+						onClick = {
+							viewModel.openEditPopup(picture)
+						}
 					) {
 						Text(
 							text = ("ID=" + picture.id + " | NAME=" + (picture.name ?: "NULL"))

--- a/app/src/main/java/com/example/csce546_project/PictureViewModel.kt
+++ b/app/src/main/java/com/example/csce546_project/PictureViewModel.kt
@@ -3,7 +3,15 @@ package com.example.csce546_project
 import android.app.Application
 import android.content.Context
 import android.net.Uri
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.Preview
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.view.CameraController
+import androidx.camera.view.LifecycleCameraController
+import androidx.camera.view.PreviewView
+import androidx.compose.runtime.remember
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
@@ -13,6 +21,7 @@ import com.example.csce546_project.database.PictureRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import org.tensorflow.lite.TensorFlowLite.init
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -30,6 +39,9 @@ class PictureViewModel(application: Application) : AndroidViewModel(application)
 
     private val _showEditPopup = MutableStateFlow(false)
     val showEditPopup: StateFlow<Boolean> = _showEditPopup
+
+    private val _enableBackgroundCamera = MutableStateFlow(true)
+    val enableBackgroundCamera: StateFlow<Boolean> = _enableBackgroundCamera
 
 
     init {
@@ -104,5 +116,15 @@ class PictureViewModel(application: Application) : AndroidViewModel(application)
         this._showAddPopup.value = false
         this._showEditPopup.value = false
         this._currentPicture.value = null
+    }
+
+    fun disableBackgroundCamera(cameraController: LifecycleCameraController) {
+        this._enableBackgroundCamera.value = false
+        cameraController.unbind()
+    }
+
+    fun enableBackgroundCamera(cameraController: LifecycleCameraController, lifecycleOwner: LifecycleOwner) {
+        cameraController.bindToLifecycle(lifecycleOwner)
+        this._enableBackgroundCamera.value = true
     }
 }

--- a/app/src/main/java/com/example/csce546_project/PictureViewModel.kt
+++ b/app/src/main/java/com/example/csce546_project/PictureViewModel.kt
@@ -3,6 +3,7 @@ package com.example.csce546_project
 import android.app.Application
 import android.content.Context
 import android.net.Uri
+import android.util.Log
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.Preview
 import androidx.camera.lifecycle.ProcessCameraProvider
@@ -21,7 +22,6 @@ import com.example.csce546_project.database.PictureRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import org.tensorflow.lite.TensorFlowLite.init
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -68,13 +68,14 @@ class PictureViewModel(application: Application) : AndroidViewModel(application)
 
     // Used for caching images taken with the camera -- NOT the permanent URI
     fun createImageFileInCache(context: Context): File {
-        val timestamp = SimpleDateFormat("yyyy_MM_dd_HH:mm:ss", Locale.US).format(Date())
-        val imageFileName = "temp_${timestamp}"
+        val imageFileName = "temp_${System.currentTimeMillis()}"
         val image = File.createTempFile(
             imageFileName,
             ".jpg",
             context.externalCacheDir
         )
+
+        Log.d("create image cache", context.externalCacheDir!!.path)
 
         return image
     }

--- a/app/src/main/java/com/example/csce546_project/PopupScreen.kt
+++ b/app/src/main/java/com/example/csce546_project/PopupScreen.kt
@@ -1,5 +1,6 @@
 package com.example.csce546_project
 
+import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
@@ -167,11 +168,15 @@ fun TakePhotoButton(
         file
     )
 
+    Log.d("TakePhoto", "File exists before launch: ${file.exists()}, path: ${file.path}")
+
     val cameraLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.TakePicture(),
         onResult = {
             viewModel.setPictureFilePath(uri)
-            // viewModel.enableBackgroundCamera(cameraController, lifecycleOwner)
+            Log.w("CAMERA", "PICTURE SUCCESSFULLY SAVED")
+            viewModel.enableBackgroundCamera(cameraController, lifecycleOwner)
+            Log.d("TakePhoto", "File exists: ${file.absolutePath}, size: ${file.length()} bytes")
         }
     )
 


### PR DESCRIPTION
System camera and CameraX preview are conflicting because they're both attempting to use the same resources. As far as I can tell I fixed this crashing the app, but the system camera still won't copy image data to the file created in cache so this option is effectively broken. All ways I've seen to supposedly free up these resources are not working, so I give up for the time being